### PR TITLE
Use floor to pick random index

### DIFF
--- a/isolate/01-application-state/examples/0-program-vs-application-state.js
+++ b/isolate/01-application-state/examples/0-program-vs-application-state.js
@@ -63,7 +63,7 @@ const renderedWords = state.words.reduce((msg, next, index) => {
 const message = `these are the random words: ${renderedWords}`;
 alert(message);
 // stores the random array index
-const favoriteIndex = Math.ceil(Math.random() * (range - 1));
+const favoriteIndex = Math.floor(Math.random() * range);
 alert(`favorite index: ${favoriteIndex}`);
 
 // use the random index to update state.favorite


### PR DESCRIPTION
When using Math.ceil with (range - 1), the favoriteIndex will never be 0 unless range is equal to 1.
By using Math.floor() it makes the code shorter and make sure 0 can be included in the result.